### PR TITLE
test: make org.jbpm.bpmn2.BPMN2XMLTest deterministic

### DIFF
--- a/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/BPMN2XMLTest.java
+++ b/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/BPMN2XMLTest.java
@@ -82,6 +82,10 @@ public class BPMN2XMLTest extends XMLTestCase {
 			sequenceDoesNotMatter.add("scriptTask");
 			sequenceDoesNotMatter.add("endEvent");
 			sequenceDoesNotMatter.add("bpmndi:BPMNShape");
+			sequenceDoesNotMatter.add("bpmndi:BPMNEdge");
+			sequenceDoesNotMatter.add("tns:import");
+			sequenceDoesNotMatter.add("tns:global");
+			sequenceDoesNotMatter.add("sequenceFlow");
 			diff.overrideDifferenceListener(new DifferenceListener() {
                 
                 public int differenceFound(Difference diff) {


### PR DESCRIPTION
  **Summary**
  - Type: deterministic comparison (iteration-order)
  - Scope: test-only; no production changes
  - Module: `jbpm-bpmn2`
  - Test: `org.jbpm.bpmn2.BPMN2XMLTest#testXML`

  **Root Cause**
  The test fails intermittently due to unordered collections  (`Set`/`Map`) producing varying XML element order for `tns:import`, `tns:global`, `sequenceFlow`, and  `bpmndi:BPMNEdge`.

  **Fix**
  Add these elements to the order-insensitive whitelist in  XMLUnit's DifferenceListener. Only child sequence differences are ignored; missing/extra nodes or attribute mismatches  still fail.

  **Validation**
  - Local: `mvn -pl jbpm-bpmn2  -Dtest=org.jbpm.bpmn2.BPMN2XMLTest#testXML test` passes  consistently
  - Scope: Test-only changes, no production impact

  **Risk**
  Low. Only ignores incidental order differences while  preserving content validation.