### PR TITLE
test: make org.jbpm.compiler.xml.processes.XMLPersistenceTest determi…

### DIFF
--- a/jbpm-flow-builder/src/test/java/org/jbpm/compiler/xml/processes/XMLPersistenceTest.java
+++ b/jbpm-flow-builder/src/test/java/org/jbpm/compiler/xml/processes/XMLPersistenceTest.java
@@ -146,7 +146,13 @@ public class XMLPersistenceTest extends XMLTestCase {
             throw new IllegalArgumentException("Failed to persist empty nodes!");
         }
        
-        assertXMLEqual(xml, xml2);
+        // Use XML comparison that ignores order of imports since they may be added automatically
+        // and their order is not semantically significant
+        Document control = XMLUnit.buildDocument(XMLUnit.newControlParser(), new StringReader(xml));
+        Document test = XMLUnit.buildDocument(XMLUnit.newTestParser(), new StringReader(xml2));
+        Diff diff = new Diff(control, test, null, new ElementNameAndAttributeQualifier("name"));
+
+        assertTrue( diff.toString(), diff.similar() );
 //        assertEquals(xml, xml2);
     }
 


### PR DESCRIPTION
**Summary**
- Type: deterministic comparison (element-order)
- Scope: test-only; no production changes
- Module: `jbpm-flow-builder`
- Test: `org.jbpm.compiler.xml.processes.XMLPersistenceTest#testEmptyNodes`

**Root Cause**
The test fails intermittently due to varying order of automatically added `import` elements in XML serialization, which are not semantically significant.

**Fix**
Replace strict `assertXMLEqual` with XMLUnit comparison using `ElementNameAndAttributeQualifier("name")` and `similar()` instead of `identical()`.

**Validation**
- Local: `mvn -pl jbpm-flow-builder -Dtest=org.jbpm.compiler.xml.processes.XMLPersistenceTest#testEmptyNodes test` passes consistently
- Scope: Test-only changes, no production impact

**Risk**
Low. Only ignores incidental import order differences while preserving content validation based on element names and attributes.